### PR TITLE
Move instance variables to accessor

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -1,10 +1,10 @@
 class Item
+  attr_accessor :name,
+                :description,
+                :unit_price,
+                :updated_at
   attr_reader :id,
-              :name,
-              :description,
-              :unit_price,
               :created_at,
-              :updated_at,
               :merchant_id
   def initialize(item_info)
     @id = item_info[:id]


### PR DESCRIPTION
Purpose of pull request:

Move name, description, unit_price, and updated_at to attr_accessor in the Item class