### PR TITLE
Refactor to pass spec harness

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -193,8 +193,9 @@ class SalesAnalyst
   def invoice_total(invoice_id)
     items = @engine.invoice_items.find_all_by_invoice_id(invoice_id)
 
-    items.map do |item|
+    total = items.map do |item|
       item.quantity * item.unit_price_to_dollars
     end.sum
+    BigDecimal(total, 10)
   end
 end

--- a/lib/transaction.rb
+++ b/lib/transaction.rb
@@ -11,8 +11,8 @@ class Transaction
   def initialize(transaction_info)
     @id = transaction_info[:id].to_i
     @invoice_id = transaction_info[:invoice_id].to_i
-    @credit_card_number = transaction_info[:credit_card_number].to_i
-    @credit_card_expiration_date = transaction_info[:credit_card_expiration_date].to_i
+    @credit_card_number = transaction_info[:credit_card_number]
+    @credit_card_expiration_date = transaction_info[:credit_card_expiration_date]
     @result = transaction_info[:result].to_sym
     @created_at = transaction_info[:created_at]
     @updated_at = transaction_info[:updated_at]

--- a/lib/transaction_repository.rb
+++ b/lib/transaction_repository.rb
@@ -47,8 +47,8 @@ class TransactionRepository < Repository
     attributes = {
       id: max_id_number_new,
       invoice_id: transaction_hash[:invoice_id].to_i,
-      credit_card_number: transaction_hash[:credit_card_number].to_i,
-      credit_card_expiration_date: transaction_hash[:credit_card_expiration_date].to_i,
+      credit_card_number: transaction_hash[:credit_card_number],
+      credit_card_expiration_date: transaction_hash[:credit_card_expiration_date],
       result: transaction_hash[:result].to_sym,
       created_at: Time.now,
       updated_at: Time.now,
@@ -60,9 +60,7 @@ class TransactionRepository < Repository
 
   def update(id, attributes)
     update_instance = find_by_id(id)
-    if update_instance.nil?
-      nil
-    else
+    if !update_instance.nil?
       update_instance.credit_card_number = attributes[:credit_card_number] unless attributes[:credit_card_number].nil?
       update_instance.credit_card_expiration_date = attributes[:credit_card_expiration_date] unless attributes[:credit_card_expiration_date].nil?
       update_instance.result = attributes[:result].to_sym unless attributes[:result].nil?


### PR DESCRIPTION
Edited storage type in transactions so that CC# and expiration were stored as strings, and SalesAnalyszer to return a big decimal for transaction total.